### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for saving and managing prompts. This tool allows you to save prompts with timestamps and list previously saved prompts.
 
+<a href="https://glama.ai/mcp/servers/@seungwonme/prompt-new-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@seungwonme/prompt-new-mcp/badge" alt="prompt-new-mcp MCP server" />
+</a>
+
 ## Installation
 
 You can run this MCP server directly using npx without installation:


### PR DESCRIPTION
This PR adds a badge for the [prompt-new-mcp](https://glama.ai/mcp/servers/@seungwonme/prompt-new-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@seungwonme/prompt-new-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@seungwonme/prompt-new-mcp/badge" alt="prompt-new-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.